### PR TITLE
remove deprecated function, transform value with toggleFormat and apply

### DIFF
--- a/addquicktag.php
+++ b/addquicktag.php
@@ -294,7 +294,9 @@ class Add_Quicktag {
 		// Alternative to JSON function
 		// wp_localize_script( self :: get_textdomain() . '_script', 'addquicktag_tags', get_option( self :: $option_string ) );
 
-		if ( function_exists( 'is_gutenberg_page' ) && is_gutenberg_page() ) {
+        $current_screen = get_current_screen();
+        // In WP 5.0 those functions do not exist no more. Not sure, if they continue to exist in the plugin.
+		if ( isset($current_screen->is_block_editor) && $current_screen->is_block_editor ) {
 			wp_enqueue_script(
 				$this->get_textdomain() . '_gutenberg',
 				plugins_url( '/js/add-quicktag-gutenberg.dev.js', __FILE__ ),

--- a/js/add-quicktag-gutenberg.dev.js
+++ b/js/add-quicktag-gutenberg.dev.js
@@ -81,16 +81,21 @@ for (let i = 0; i < tags.length; i++) {
                     element = create({
                         'html' : toInsert
                     });
-                    onChange(insert(value, element));
+                    if( element.formats.length === 0 ) {
+                        return;
+                    }
+                    for ( let i = element.formats[0].length - 1; i >= 0; i-- ) {
+                        value = toggleFormat(value, element.formats[0][i]);
+                    }
+                    onChange(value);
                 };
-                const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 
                 return (
                     createElement(Fragment, null,
                         createElement(RichTextShortcut, {
                             type : 'primary',
                             character,
-                            onUse: onToggle
+                            onUse: onClick
                         }),
                         createElement(RichTextToolbarButton, {
                             icon,


### PR DESCRIPTION
Has been tested with `<b class="highlight"><i>` and `</i></b>`

Basically, we use `create()` just to see, what formats are applied to create. We run through all those formats in reverse order (Haven't tested the other way, my thinking was to remove the elements from inside out) and do `toggleFormat()` for each of those formats. After we have removed the formats, we return it to `onChange()`

https://im.ezgif.com/tmp/ezgif-1-5413a4035503.gif
I did run into a problem with crazy testing but I can't reproduce it and my first impression was, this could also be a problem of Gutenberg. But this PR needs testing.

Unrelated:
This PR also changes the way, we detect Gutenberg. I think `is_gutenberg_page()` was only used in the plugin. We can detect the editor screen with `get_current_screen()`

Currently out of scope:
The button should be marked as active, this somehow does not apply yet, but I didnt had a look. I have two different Quicktags registered, but only the first shows up. But I think these are problems for a different PR.